### PR TITLE
Reorder docker operations to optimize docker cache

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:18-alpine as build
 WORKDIR /app
-COPY . .
+COPY package.json package.json
 RUN npm install
+COPY . .
 RUN npm run build-prod
 
 FROM nginx:stable as run


### PR DESCRIPTION
First, we copy the package.json so we do not need to npm install everytime, but use the cache instead. Afterwards, we copy the whole folder.