### PR TITLE
Implemented basic ordering

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ./frontend
     image: baas_frontend
     ports: 
-      - 4200:80
+      - 4201:80
     healthcheck:
       test: wget localhost:80 --no-verbose --tries=1 --spider || exit 1
       interval: 5s

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@angular/cli": "^17.3.3",
         "@angular/compiler-cli": "^17.3.0",
         "@types/jasmine": "~5.1.0",
+        "@types/node": "^20.12.12",
         "jasmine-core": "~5.1.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -3679,9 +3680,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@angular/cli": "^17.3.3",
     "@angular/compiler-cli": "^17.3.0",
     "@types/jasmine": "~5.1.0",
+    "@types/node": "^20.12.12",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/frontend/src/app/basket.service.ts
+++ b/frontend/src/app/basket.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@angular/core';
-import { Product } from './backend.service';
+import { BackendService, Order, OrderItem, Product } from './backend.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class BasketService {
+  constructor(public backendService: BackendService) {
+
+  }
+
   getAll(): string[] {
       const item = localStorage.getItem("products");
 
@@ -33,6 +37,35 @@ export class BasketService {
     products.splice(index, 1);
 
     localStorage.setItem("products", JSON.stringify(products));
+  }
+
+  order(customer_id: string, products: Product[]): void {
+    const order: Order = {
+      id: undefined,
+      customer_id: customer_id,
+      status: "ordered",
+      total_price: products.reduce((sum, current) => sum + parseFloat(current.price + ""), 0),
+      date_created: undefined,
+    };
+
+    var items: OrderItem[] = [];
+
+    this.backendService.createOrder(order)
+      .then((order) => {
+        console.log(order)
+
+        products.forEach((product) => {
+          items.push({
+            id: undefined,
+            order_id: order.id!,
+            quantity: 1,
+            price_per_item: product.price,
+            product_id: product.id
+          });
+        });
+
+        this.backendService.createOrderItems(items)
+    });
   }
 
   clearAll(): void {

--- a/frontend/src/app/basket/basket.component.html
+++ b/frontend/src/app/basket/basket.component.html
@@ -16,4 +16,4 @@
     }
 </table>
 
-<button>Checkout</button>
+<button (click)="checkout()">Checkout</button>

--- a/frontend/src/app/basket/basket.component.spec.ts
+++ b/frontend/src/app/basket/basket.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BasketComponent } from './basket.component';
+import { provideRouter } from '@angular/router';
 
 describe('BasketComponent', () => {
   let component: BasketComponent;
@@ -8,7 +9,8 @@ describe('BasketComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [BasketComponent]
+      imports: [BasketComponent],
+      providers: [provideRouter([])]
     })
     .compileComponents();
     

--- a/frontend/src/app/basket/basket.component.ts
+++ b/frontend/src/app/basket/basket.component.ts
@@ -27,4 +27,8 @@ export class BasketComponent implements OnInit {
         .catch((err) => console.error(err));
     });
   }
+
+  checkout(): void {
+    this.basketService.order(this.backendService.getId()!, this.products);
+  }
 }


### PR DESCRIPTION
Calls the directus endpoint to create orders and order items.
However, this functionality is not ACID because orders and order items are created on the frontend. The correct solution requires an endpoint in directus.
Also every item is here a single. This means that 1000 "Semmerl" are 1000 Order Items. So there is room for improvement.