### PR TITLE
Update registry to GCP

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ on:
 
 env:
   PUSH_IMAGES: ${{ github.ref_protected && (startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/main') ) }}
+  REGISTRY: ${{ env.USE_GCP && env.GCP_REGISTRY || 'ghcr.io' }}
+  REPOSITORY_NAME: ${{ env.USE_GCP && env.GCP_REPOSITORY_NAME || 'austriandatalab' }}
+  REGISTRY_USER: ${{ env.USE_GCP && env.GCP_REGISTRY_USER || github.actor }}
+  REGISTRY_PASSWORD: ${{ env.USE_GCP && secrets.GOOGLE_REGISTRY_PUSH_CREDENTIALS || secrets.GITHUB_TOKEN }}
   IMAGE_NAME_BACKEND: baas-backend
   IMAGE_NAME_FRONTEND: baas-frontend
   IMAGE_NAME_DOCUMENT: baas-document
@@ -30,7 +34,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.GOOGLE_REGISTRY_PUSH_CREDENTIALS }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -77,7 +81,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.GOOGLE_REGISTRY_PUSH_CREDENTIALS }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -124,7 +128,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.GOOGLE_REGISTRY_PUSH_CREDENTIALS }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -179,4 +183,4 @@ jobs:
         run: .github/workflows/push_helm.sh
         env:
           REGISTRY_USERNAME: ${{ env.REGISTRY_USER }}
-          REGISTRY_ACCESS_TOKEN: ${{ env.GOOGLE_REGISTRY_PUSH_CREDENTIALS }}
+          REGISTRY_ACCESS_TOKEN: ${{ env.REGISTRY_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,6 @@ on:
 
 env:
   PUSH_IMAGES: ${{ github.ref_protected && (startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/main') ) }}
-  REGISTRY: ghcr.io
-  REPOSITORY_NAME: austriandatalab
   IMAGE_NAME_BACKEND: baas-backend
   IMAGE_NAME_FRONTEND: baas-frontend
   IMAGE_NAME_DOCUMENT: baas-document
@@ -31,8 +29,8 @@ jobs:
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.GOOGLE_REGISTRY_PUSH_CREDENTIALS }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -78,8 +76,8 @@ jobs:
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.GOOGLE_REGISTRY_PUSH_CREDENTIALS }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -125,8 +123,8 @@ jobs:
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.GOOGLE_REGISTRY_PUSH_CREDENTIALS }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -180,5 +178,5 @@ jobs:
       - name: Push helm chart to registry
         run: .github/workflows/push_helm.sh
         env:
-          REGISTRY_USERNAME: ${{ github.actor }}
-          REGISTRY_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_USERNAME: ${{ env.REGISTRY_USER }}
+          REGISTRY_ACCESS_TOKEN: ${{ env.GOOGLE_REGISTRY_PUSH_CREDENTIALS }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
 env:
   # build on tags/main and pull_requests
   # the GCP repository is only exposed for protected branches, i.e. main
-  PUSH_IMAGES: ${{ startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/main') || github.event_name == 'pull_request' }}
+  PUSH_IMAGES: ${{ startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/main') }}
   REGISTRY: ${{ env.USE_GCP && env.GCP_REGISTRY || 'ghcr.io' }}
   REPOSITORY_NAME: ${{ env.USE_GCP && env.GCP_REPOSITORY_NAME || 'austriandatalab' }}
   REGISTRY_USER: ${{ env.USE_GCP && env.GCP_REGISTRY_USER || github.actor }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,9 @@ on:
       - 'v*'
 
 env:
-  PUSH_IMAGES: ${{ github.ref_protected && (startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/main') ) }}
+  # build on tags/main and pull_requests
+  # the GCP repository is only exposed for protected branches, i.e. main
+  PUSH_IMAGES: ${{ startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.event.ref, 'refs/heads/main') || github.event_name == 'pull_request' }}
   REGISTRY: ${{ env.USE_GCP && env.GCP_REGISTRY || 'ghcr.io' }}
   REPOSITORY_NAME: ${{ env.USE_GCP && env.GCP_REPOSITORY_NAME || 'austriandatalab' }}
   REGISTRY_USER: ${{ env.USE_GCP && env.GCP_REGISTRY_USER || github.actor }}

--- a/charts/baas/Chart.yaml
+++ b/charts/baas/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: baas
-description: A Helm chart for deploying baas
+description: Helm chart to deploy a Bakery-as-a-service (BaaS) instance 
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -23,9 +23,13 @@ version: 0.3.2
 # It is recommended to use it with quotes.
 appVersion: "0.3.2"
 
-
 dependencies:
   - name: "valkey"
     version: "~0.3.5"
     repository: "https://charts.bitnami.com/bitnami"
     condition: valkey.enable
+
+annotations:
+  catalog.cattle.io/display-name: "Bakery as a service"
+  catalog.cattle.io/requests-cpu: 1000m
+  catalog.cattle.io/requests-memory: 2Gi

--- a/charts/baas/templates/directus-deployment.yaml
+++ b/charts/baas/templates/directus-deployment.yaml
@@ -17,6 +17,12 @@ spec:
     spec:
       containers:
       - env:
+        - name: CUSTOM_FQDN
+          value: "{{ .Values.customFqdn }}"
+        - name: CUSTOM_NAME
+          value: "{{ .Values.customName }}"
+        - name: CUSTOM_EMAIL
+          value: "{{ .Values.customEmail }}"
         - name: KEY
           value: "{{ .Values.directus.key }}"
         - name: SECRET

--- a/charts/baas/templates/frontend-deployment.yaml
+++ b/charts/baas/templates/frontend-deployment.yaml
@@ -38,3 +38,10 @@ spec:
             memory: {{ .Values.frontend.resources.requests.memory }}
       restartPolicy: {{ .Values.frontend.restartPolicy }}
       terminationGracePeriodSeconds: {{ .Values.frontend.terminationGracePeriodSeconds }}
+      env:
+        - name: CUSTOM_FQDN
+          value: "{{ .Values.customFqdn }}"
+        - name: CUSTOM_NAME
+          value: "{{ .Values.customName }}"
+        - name: CUSTOM_EMAIL
+          value: "{{ .Values.customEmail }}"

--- a/charts/baas/values.yaml
+++ b/charts/baas/values.yaml
@@ -1,4 +1,8 @@
 
+# From rancher app form
+customFqdn: "from.rancher.app.questions"
+customName: "from.rancher.app.questions"
+customEmail: "from.rancher.app.questions"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Builds and pushes when
* on main
* on tags
* on pull_requests
The GCP secret is only set on protected branches, i.e. main
otherwise, the images are pushed to ghcr.io. This enables trivy scans